### PR TITLE
Update for clientbuffer ZNC 1.7.2 compatibility

### DIFF
--- a/ZNC/ZNC-deployment.sh
+++ b/ZNC/ZNC-deployment.sh
@@ -75,10 +75,12 @@ systemctl enable znc
 # done install ZNC
 # set up clientbuffer module
 cd /root/
-# # this clientbuffer fork originally fixed the duplicate query message issue, but is no longer available:
-# # curl -o clientbuffer.cpp https://raw.githubusercontent.com/blole/znc-clientbuffer/master/clientbuffer.cpp
-# this is now the official plugin repo:
-curl -o clientbuffer.cpp -L https://raw.githubusercontent.com/CyberShadow/znc-clientbuffer/master/clientbuffer.cpp
+# # # this clientbuffer fork originally fixed the duplicate query message issue, but is no longer available:
+# # # curl -o clientbuffer.cpp https://raw.githubusercontent.com/blole/znc-clientbuffer/master/clientbuffer.cpp
+# # this is now the official plugin repo:
+# # curl -o clientbuffer.cpp -L https://raw.githubusercontent.com/CyberShadow/znc-clientbuffer/master/clientbuffer.cpp
+# updated temporary repo to make this module compatible with ZNC 1.7.2:
+curl -o clientbuffer.cpp -L https://raw.githubusercontent.com/wireframeskull/znc-clientbuffer/master/clientbuffer.cpp
 yum install -y gcc-c++ redhat-rpm-config
 /bin/znc-buildmod clientbuffer.cpp
 mv clientbuffer.so /usr/lib64/znc/


### PR DESCRIPTION
The current official clientbuffer module breaks ZNC 1.7.2 with a compatibility error.

Changed source for clientbuffer module to a repo that modifies its version compatibility.